### PR TITLE
Added exception handling for Pictures API, fixed previous_picture_id bug

### DIFF
--- a/Backend/PicturesAPI/app/actions/history_actions.py
+++ b/Backend/PicturesAPI/app/actions/history_actions.py
@@ -78,10 +78,16 @@ class HistoryActions:
         :param history: new history record to be added
         :return: History instance
         """
-        db_history = models.History(picture_id=history.picture_id, original_picture_id=history.original_picture_id,
-                                    hair_colour_id=history.hair_colour_id,
-                                    hair_style_id=history.hair_style_id, face_shape_id=history.face_shape_id,
-                                    user_id=history.user_id)
+        db_history: models.History = models.History(
+            picture_id=history.picture_id,
+            original_picture_id=history.original_picture_id,
+            previous_picture_id=history.previous_picture_id,
+            hair_colour_id=history.hair_colour_id,
+            hair_style_id=history.hair_style_id,
+            face_shape_id=history.face_shape_id,
+            user_id=history.user_id
+        )
+
         db.add(db_history)
         db.commit()
         db.refresh(db_history)
@@ -130,6 +136,7 @@ class HistoryActions:
         if latest_history_entry is not None:
             new_history_entry = models.History(picture_id=latest_history_entry.picture_id,
                                                original_picture_id=latest_history_entry.original_picture_id,
+                                               previous_picture_id=latest_history_entry.previous_picture_id,
                                                hair_colour_id=latest_history_entry.hair_colour_id,
                                                hair_style_id=latest_history_entry.hair_style_id,
                                                face_shape_id=history_record_with_new_face_shape.face_shape_id,

--- a/Backend/PicturesAPI/app/actions/picture_actions.py
+++ b/Backend/PicturesAPI/app/actions/picture_actions.py
@@ -4,11 +4,11 @@ from sqlalchemy.orm import Session
 
 from app import models
 from app.models.picture import Picture
-from app.schemas.picture import PictureCreateUpdate
+from app.schemas.picture import PictureCreate
 
 
 class PictureActions:
-    def add_picture(self, db: Session, picture: PictureCreateUpdate):
+    def add_picture(self, db: Session, picture: PictureCreate):
         db_picture = Picture(file_name=picture.file_name, file_path=picture.file_path, file_size=picture.file_size,
                              height=picture.height, width=picture.width)
         db.add(db_picture)

--- a/Backend/PicturesAPI/app/models/history.py
+++ b/Backend/PicturesAPI/app/models/history.py
@@ -37,7 +37,17 @@ class History(Base):
     user = relationship("User", back_populates="history")
 
     def __repr__(self):
-        return "<User's history entry (user_id = '%s')>" % self.user_id
+        return 'History entry:\n' + \
+               f'id: {self.id}\n' + \
+               f'picture_id: {self.picture_id}\n' + \
+               f'original_picture_id: {self.original_picture_id}\n' + \
+               f'previous_picture_id: {self.previous_picture_id}\n' + \
+               f'hair_colour_id: {self.hair_colour_id}\n' + \
+               f'hair_style_id: {self.hair_style_id}\n' + \
+               f'face_shape_id: {self.face_shape_id}\n' + \
+               f'user_id: {self.user_id}\n' + \
+               f'date_created: {self.date_created}\n' + \
+               f'date_updated: {self.date_updated}\n'
 
 
 Picture.history = relationship(

--- a/Backend/PicturesAPI/app/models/picture.py
+++ b/Backend/PicturesAPI/app/models/picture.py
@@ -12,3 +12,14 @@ class Picture(Base):
     width = Column(Integer)
     date_created = Column(DateTime(timezone=True), server_default=func.now())
     date_updated = Column(DateTime(timezone=True), server_default=text("NULL"), onupdate=func.now())
+
+    def __repr__(self):
+        return 'Picture entry:' + \
+               f'id: {self.id}\n' + \
+               f'file_name: {self.file_name}\n' + \
+               f'file_path: {self.file_path}\n' + \
+               f'file_size: {self.file_size}\n' + \
+               f'height: {self.height}\n' + \
+               f'width: {self.width}\n' + \
+               f'date_created: {self.date_created}\n' + \
+               f'date_updated: {self.date_updated}\n'

--- a/Backend/PicturesAPI/app/routers/history.py
+++ b/Backend/PicturesAPI/app/routers/history.py
@@ -128,20 +128,16 @@ async def add_face_shape(history_record_with_new_face_shape: schemas.HistoryAddF
     user_entry = db.query(models.User).filter(models.User.id == history_record_with_new_face_shape.user_id).first()
 
     if face_shape_entry is None or user_entry is None:
-        response.status_code = status.HTTP_404_NOT_FOUND
-        return {
-            "message": "Face shape or user entry not found"
-        }
+        raise HTTPException(status_code=404, detail='Face shape or user entry not found')
 
     new_history_record = history_actions.add_face_shape(db=db,
                                                         history_record_with_new_face_shape=history_record_with_new_face_shape)
 
     if new_history_record is None:
-        response.status_code = status.HTTP_400_BAD_REQUEST
-        return {
-            "message": "There is no previous history record associated with this user. Please upload a picture first "
-                       "and then update your face shape."
-        }
+        raise HTTPException(status_code=400,
+                            detail='There is no previous history record associated with this user. Please upload a '
+                                   'picture first'
+                                   ' and then update your face shape.')
 
     return new_history_record
 

--- a/Backend/PicturesAPI/app/schemas/__init__.py
+++ b/Backend/PicturesAPI/app/schemas/__init__.py
@@ -9,4 +9,4 @@ from .hair_length_link import HairLengthLink, HairLengthLinkBase, HairLengthLink
 from .face_shape_link import FaceShapeLinkBase, FaceShapeLink, FaceShapeLinkCreateUpdate
 from .history import HistoryBase, History, HistoryCreate, HistoryUpdate, HistoryAddFaceShape
 from .model_picture import ModelPictureBase, ModelPicture, ModelPictureCreate, ModelPictureUpdate
-from .picture import Picture, PictureCreateUpdate, PictureBase, PictureInfo
+from .picture import Picture, PictureBase, PictureCreate, PictureUpdate, PictureInfo

--- a/Backend/PicturesAPI/app/schemas/picture.py
+++ b/Backend/PicturesAPI/app/schemas/picture.py
@@ -13,12 +13,16 @@ class PictureBase(BaseModel):
     width: int
 
 
-class PictureCreateUpdate(PictureBase):
+class PictureCreate(BaseModel):
     file_name: constr(max_length=255)
     file_path: constr(max_length=255)
     file_size: conint(ge=0)
     height: conint(ge=0)
     width: conint(ge=0)
+
+
+class PictureUpdate(PictureCreate):
+    id: int
 
 
 class PictureInfo(BaseModel):

--- a/app/lib/models/hair_colour.dart
+++ b/app/lib/models/hair_colour.dart
@@ -35,14 +35,6 @@ class HairColour {
         dateCreated = json['date_created'],
         dateUpdated = json['date_updated'];
 
-  HairColour.fromJson2(Map<String, dynamic> json)
-      : id = json['id'],
-        colourName = json['colour_name'],
-        colourHash = json['colour_hash'],
-        label = json['label'],
-        dateCreated = json['date_created'],
-        dateUpdated = json['date_updated'];
-
   Map<String, dynamic> toJson() => {
         'id': this.id,
         'colour_name': this.colourName,

--- a/app/lib/services/authentication.dart
+++ b/app/lib/services/authentication.dart
@@ -17,7 +17,7 @@ class Authentication {
       final response = await post(signInUri, body: encodedUser, headers: {
         "Content-Type": "application/json",
         "Origin": ADMIN_PORTAL_URL
-      }).timeout(const Duration(seconds: 5));
+      }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
       return response;
     } catch (err) {
       print('Server connection timed out');
@@ -34,7 +34,7 @@ class Authentication {
       return await post(signUpUri, body: encodedUser, headers: {
         "Content-Type": "application/json",
         "Origin": ADMIN_PORTAL_URL
-      }).timeout(const Duration(seconds: 5));
+      }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
     } catch (err) {
       print('Server connection timed out');
       print(err);
@@ -110,7 +110,7 @@ class Authentication {
             headers: {
               "Authorization": "Bearer $userToken",
               "Origin": ADMIN_PORTAL_URL
-            }).timeout(const Duration(seconds: 5));
+            }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
 
         final authData =
             UserAuthenticate.fromJson(jsonDecode(authResponse.body));
@@ -140,7 +140,8 @@ class Authentication {
           final response = await get(authenticationUri, headers: {
             "Authorization": "Bearer $localToken",
             "Origin": ADMIN_PORTAL_URL
-          }).timeout(Duration(seconds: 5), onTimeout: () => null);
+          }).timeout(Duration(seconds: DEFAULT_TIMEOUT_SECONDS),
+              onTimeout: () => null);
 
           if (response.statusCode == HttpStatus.ok) {
             final UserAuthenticate authenticatedUserData =
@@ -152,7 +153,8 @@ class Authentication {
             final userResponse = await get(userUri, headers: {
               "Authorization": "Bearer $localToken",
               "Origin": ADMIN_PORTAL_URL
-            }).timeout(const Duration(seconds: 5), onTimeout: () => null);
+            }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS),
+                onTimeout: () => null);
 
             if (userResponse.statusCode == HttpStatus.ok) {
               final user = User.fromJson(jsonDecode(userResponse.body)['user']);

--- a/app/lib/services/constants.dart
+++ b/app/lib/services/constants.dart
@@ -2,3 +2,4 @@ const String USERS_API_URL = 'http://10.0.2.2:5050';
 const String PICTURES_API_URL = 'http://10.0.2.2:8000';
 const String ADMIN_PORTAL_URL = 'https://styleme.best';
 const String TOKEN_FILENAME = 'token.txt';
+const int DEFAULT_TIMEOUT_SECONDS = 30;

--- a/app/lib/services/face_shape.dart
+++ b/app/lib/services/face_shape.dart
@@ -18,7 +18,7 @@ class FaceShapeService {
         final response = await http.get(uri, headers: {
           "Authorization": "Bearer $userToken",
           "Origin": ADMIN_PORTAL_URL
-        }).timeout(const Duration(seconds: 10));
+        }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
 
         return response;
       }
@@ -38,7 +38,7 @@ class FaceShapeService {
         final response = await http.get('$faceShapeBaseUri/$id', headers: {
           "Authorization": "Bearer $userToken",
           "Origin": ADMIN_PORTAL_URL
-        }).timeout(const Duration(seconds: 10));
+        }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
 
         return response;
       }

--- a/app/lib/services/hair_colour.dart
+++ b/app/lib/services/hair_colour.dart
@@ -18,7 +18,7 @@ class HairColourService {
         final response = await http.get(uri, headers: {
           "Authorization": "Bearer $userToken",
           "Origin": ADMIN_PORTAL_URL
-        }).timeout(const Duration(seconds: 10));
+        }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
 
         return response;
       }
@@ -38,7 +38,7 @@ class HairColourService {
         final response = await http.get('$hairColourBaseUri/$id', headers: {
           "Authorization": "Bearer $userToken",
           "Origin": ADMIN_PORTAL_URL
-        }).timeout(const Duration(seconds: 10));
+        }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
 
         return response;
       }

--- a/app/lib/services/hair_length.dart
+++ b/app/lib/services/hair_length.dart
@@ -19,7 +19,7 @@ class HairLengthService {
         final response = await http.get(uri, headers: {
           "Authorization": "Bearer $userToken",
           "Origin": ADMIN_PORTAL_URL
-        }).timeout(const Duration(seconds: 10));
+        }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
 
         return response;
       }
@@ -39,7 +39,7 @@ class HairLengthService {
         final response = await http.get('$hairLengthBaseUri/$id', headers: {
           "Authorization": "Bearer $userToken",
           "Origin": ADMIN_PORTAL_URL
-        }).timeout(const Duration(seconds: 10));
+        }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
 
         return response;
       }

--- a/app/lib/services/hair_style.dart
+++ b/app/lib/services/hair_style.dart
@@ -19,7 +19,7 @@ class HairStyleService {
         final response = await http.get(uri, headers: {
           "Authorization": "Bearer $userToken",
           "Origin": ADMIN_PORTAL_URL
-        }).timeout(const Duration(seconds: 10));
+        }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
 
         return response;
       }
@@ -39,7 +39,7 @@ class HairStyleService {
         final response = await http.get('$hairStyleBaseUri/$id', headers: {
           "Authorization": "Bearer $userToken",
           "Origin": ADMIN_PORTAL_URL
-        }).timeout(const Duration(seconds: 10));
+        }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
 
         return response;
       }

--- a/app/lib/services/history.dart
+++ b/app/lib/services/history.dart
@@ -17,7 +17,7 @@ class HistoryService {
         final response = await http.get('$historyBaseUri/$historyId', headers: {
           "Authorization": "Bearer $userToken",
           "Origin": ADMIN_PORTAL_URL
-        }).timeout(const Duration(seconds: 10));
+        }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
         return response;
       }
       return null;
@@ -41,7 +41,7 @@ class HistoryService {
                   "Origin": ADMIN_PORTAL_URL
                 },
                 body: history.toJson())
-            .timeout(const Duration(seconds: 10));
+            .timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
 
         return response;
       }
@@ -62,7 +62,7 @@ class HistoryService {
             headers: {
               "Authorization": "Bearer $userToken",
               "Origin": ADMIN_PORTAL_URL
-            }).timeout(const Duration(seconds: 10));
+            }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
 
         return response;
       }
@@ -86,7 +86,7 @@ class HistoryService {
           headers: {
             "Authorization": "Bearer $userToken",
             "Origin": ADMIN_PORTAL_URL
-          });
+          }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
 
       return historyResponse;
     } catch (err) {
@@ -106,7 +106,7 @@ class HistoryService {
             headers: {
               "Authorization": "Bearer $userToken",
               "Origin": ADMIN_PORTAL_URL
-            }).timeout(const Duration(seconds: 10));
+            }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
 
         return response;
       }
@@ -126,7 +126,7 @@ class HistoryService {
         final response = await http.get('$historyBaseUri', headers: {
           "Authorization": "Bearer $userToken",
           "Origin": ADMIN_PORTAL_URL
-        }).timeout(const Duration(seconds: 10));
+        }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
 
         return response;
       }
@@ -151,7 +151,7 @@ class HistoryService {
                   "Origin": ADMIN_PORTAL_URL
                 },
                 body: jsonEncode(history.toJson()))
-            .timeout(const Duration(seconds: 10));
+            .timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
 
         return response;
       }
@@ -182,7 +182,7 @@ class HistoryService {
                 },
                 body: jsonEncode(body),
                 encoding: Encoding.getByName('utf-8'))
-            .timeout(const Duration(seconds: 10));
+            .timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
 
         return response;
       }

--- a/app/lib/services/model_pictures.dart
+++ b/app/lib/services/model_pictures.dart
@@ -19,7 +19,7 @@ class ModelPicturesService {
             headers: {
               "Origin": ADMIN_PORTAL_URL,
               "Authorization": "Bearer $userToken"
-            }).timeout(const Duration(seconds: 10));
+            }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
         return response;
       }
       return null;
@@ -41,7 +41,7 @@ class ModelPicturesService {
             headers: {
               "Origin": ADMIN_PORTAL_URL,
               "Authorization": "Bearer $userToken"
-            }).timeout(const Duration(seconds: 10));
+            }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
         return response;
       }
       return null;
@@ -62,7 +62,7 @@ class ModelPicturesService {
             headers: {
               "Origin": ADMIN_PORTAL_URL,
               "Authorization": "Bearer $userToken"
-            }).timeout(const Duration(seconds: 10));
+            }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
         return response;
       }
       return null;

--- a/app/lib/services/pictures.dart
+++ b/app/lib/services/pictures.dart
@@ -44,7 +44,7 @@ class PicturesService {
             .get(Uri.encodeFull('$picturesUri/id/$pictureId'), headers: {
           "Authorization": "Bearer $userToken",
           "Origin": ADMIN_PORTAL_URL
-        }).timeout(const Duration(seconds: 10));
+        }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
         return response;
       }
       return null;
@@ -64,7 +64,7 @@ class PicturesService {
             .get(Uri.encodeFull('$picturesUri/file/$pictureId'), headers: {
           "Authorization": "Bearer $userToken",
           "Origin": ADMIN_PORTAL_URL
-        }).timeout(const Duration(seconds: 10));
+        }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
         return response;
       }
       return null;
@@ -87,7 +87,7 @@ class PicturesService {
             headers: {
               "Authorization": "Bearer $userToken",
               "Origin": ADMIN_PORTAL_URL
-            }).timeout(const Duration(seconds: 10));
+            }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
         return response;
       }
       return null;
@@ -110,7 +110,7 @@ class PicturesService {
             headers: {
               "Authorization": "Bearer $userToken",
               "Origin": ADMIN_PORTAL_URL
-            }).timeout(const Duration(seconds: 10));
+            }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
         return response;
       }
       return null;
@@ -132,7 +132,7 @@ class PicturesService {
             headers: {
               "Authorization": "Bearer $userToken",
               "Origin": ADMIN_PORTAL_URL
-            }).timeout(const Duration(seconds: 10));
+            }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
         return response;
       }
       return null;
@@ -154,7 +154,7 @@ class PicturesService {
             headers: {
               "Authorization": "Bearer $userToken",
               "Origin": ADMIN_PORTAL_URL
-            }).timeout(const Duration(seconds: 10));
+            }).timeout(const Duration(seconds: DEFAULT_TIMEOUT_SECONDS));
         return response;
       }
       return null;

--- a/app/lib/views/pages/home.dart
+++ b/app/lib/views/pages/home.dart
@@ -215,6 +215,8 @@ class _HomeState extends State<Home> {
 
           if (_currentFaceShape != null) {
             _completedRoutes.add(SelectFaceShape.routeName);
+          } else {
+            _completedRoutes.remove(SelectFaceShape.routeName);
           }
 
           _currentHairStyle = await _fetchLatestHairStyleEntry();
@@ -223,6 +225,8 @@ class _HomeState extends State<Home> {
 
           if (_currentHairStyle != null) {
             _completedRoutes.add(SelectHairStyle.routeName);
+          } else {
+            _completedRoutes.remove(SelectHairStyle.routeName);
           }
 
           _currentHairColour = await _fetchLatestHairColourEntry();
@@ -231,6 +235,8 @@ class _HomeState extends State<Home> {
 
           if (_currentHairColour != null) {
             _completedRoutes.add(SelectHairColour.routeName);
+          } else {
+            _completedRoutes.remove(SelectHairColour.routeName);
           }
 
           _currentPicture = latestPicture;

--- a/app/lib/views/pages/home.dart
+++ b/app/lib/views/pages/home.dart
@@ -325,10 +325,11 @@ class _HomeState extends State<Home> {
       FaceShape newFaceShape,
       String message}) {
     setState(() {
+      _currentPictureFuture = _fetchLatestPictureEntry();
+      _completedRoutes.clear();
       _completedRoutes.add(UploadPicture.routeName);
       _history.add(historyEntryAdded);
       _currentPicture = newPicture;
-      _currentPictureFuture = _fetchLatestPictureEntry();
       _currentFaceShape = newFaceShape;
       _message = message ?? 'Picture successfully uploaded';
     });
@@ -336,8 +337,14 @@ class _HomeState extends State<Home> {
     NotificationService.notify(scaffoldKey: scaffoldKey, message: _message);
   }
 
-  void _onFaceShapeUpdated({@required FaceShape newFaceShape, String message}) {
+  void _onFaceShapeUpdated(
+      {@required FaceShape newFaceShape,
+      @required History newHistoryEntry,
+      String message}) {
     setState(() {
+      _currentPictureFuture = _fetchLatestPictureEntry();
+      _completedRoutes.clear();
+      _completedRoutes.add(UploadPicture.routeName);
       _completedRoutes.add(SelectFaceShape.routeName);
       _currentFaceShape = newFaceShape;
       _message = message ?? 'Face shape updated to ${newFaceShape.label}';
@@ -349,10 +356,12 @@ class _HomeState extends State<Home> {
 
   void _onHairStyleUpdated({@required HairStyle newHairStyle, String message}) {
     setState(() {
+      _currentPictureFuture = _fetchLatestPictureEntry();
+      _completedRoutes.clear();
+      _completedRoutes.add(UploadPicture.routeName);
       _completedRoutes.add(SelectFaceShape.routeName);
       _completedRoutes.add(SelectHairStyle.routeName);
       _currentHairStyle = newHairStyle;
-      _currentPictureFuture = _fetchLatestPictureEntry();
       _message = message ?? 'Hair style updated to ${newHairStyle.label}';
     });
 
@@ -362,13 +371,15 @@ class _HomeState extends State<Home> {
   void _onHairColourUpdated(
       {@required HairColour newHairColour, String message}) {
     setState(() {
+      _currentPictureFuture = _fetchLatestPictureEntry();
+      _completedRoutes.clear();
+      _completedRoutes.add(UploadPicture.routeName);
+      _completedRoutes.add(SelectFaceShape.routeName);
+      _completedRoutes.add(SelectHairStyle.routeName);
       _completedRoutes.add(SelectHairColour.routeName);
       _currentHairColour = newHairColour;
       _message = message ?? 'Hair colour updated to ${newHairColour.label}';
     });
-
-    // update current picture
-    _currentPictureFuture = _fetchLatestPictureEntry();
 
     NotificationService.notify(scaffoldKey: scaffoldKey, message: _message);
   }

--- a/app/lib/views/pages/select_face_shape.dart
+++ b/app/lib/views/pages/select_face_shape.dart
@@ -116,12 +116,16 @@ class _SelectFaceShapeState extends State<SelectFaceShape> {
     if (response.statusCode == HttpStatus.ok ||
         response.statusCode == HttpStatus.created) {
       _onFaceShapeUpdated(
-          newFaceShape: _faceShapes
-              .firstWhere((element) => element.id == _selectedFaceShape.id));
+          newFaceShape: _faceShapes.firstWhere(
+        (element) => element.id == _selectedFaceShape.id,
+        orElse: () => null,
+      ));
       setState(() {
         _isLoading = false;
-        _initialFaceShape = _faceShapes
-            .firstWhere((element) => element.id == _initialFaceShape.id);
+        _initialFaceShape = _faceShapes.firstWhere(
+          (element) => element.id == _initialFaceShape.id,
+          orElse: () => null,
+        );
       });
       Navigator.pop(context);
     } else {

--- a/app/lib/views/pages/select_hair_colour.dart
+++ b/app/lib/views/pages/select_hair_colour.dart
@@ -55,7 +55,6 @@ class _SelectHairColourState extends State<SelectHairColour> {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
 
   _saveChanges() {
-    // TODO: Save _selectedColour
     print('Cahnging hair colour to ${_selectedColourCard.colourLabel}');
     _changeHairColour();
   }
@@ -74,19 +73,14 @@ class _SelectHairColourState extends State<SelectHairColour> {
           r: _r,
           g: _g,
           b: _b);
-      if (response.statusCode == HttpStatus.ok &&
-          response.body.isNotEmpty) {
-        
+      if (response.statusCode == HttpStatus.ok && response.body.isNotEmpty) {
         final History historyEntry =
-          History.fromJson(jsonDecode(response.body));
+            History.fromJson(jsonDecode(response.body));
 
         final HairColour hairColourEntry =
-          HairColour.fromJson2(jsonDecode(response.body)['hair_colour']);       
+            HairColour.fromJson(jsonDecode(response.body)['hair_colour']);
 
-
-        widget.onHairColourUpdated(
-          newHairColour: hairColourEntry
-        );
+        widget.onHairColourUpdated(newHairColour: hairColourEntry);
 
         // update current colour
         _currentHairColour = hairColourEntry;

--- a/app/lib/views/pages/select_hair_style.dart
+++ b/app/lib/views/pages/select_hair_style.dart
@@ -102,7 +102,12 @@ class _SelectHairStyleState extends State<SelectHairStyle> {
                 select: _selectHairStyle,
                 modelPicture: card.modelPicture,
                 modelPictureWidget: Image.network(
-                    '${ModelPicturesService.modelPicturesUri}/file/${card.id}'),
+                  '${ModelPicturesService.modelPicturesUri}/file/${card.id}',
+                  headers: {
+                    "Origin": ADMIN_PORTAL_URL,
+                    "Authorization": "Bearer ${widget.userToken}"
+                  },
+                ),
                 selected: true,
                 type: card.type);
           } else {
@@ -112,7 +117,12 @@ class _SelectHairStyleState extends State<SelectHairStyle> {
               select: _selectHairStyle,
               modelPicture: card.modelPicture,
               modelPictureWidget: Image.network(
-                  '${ModelPicturesService.modelPicturesUri}/file/${card.id}'),
+                '${ModelPicturesService.modelPicturesUri}/file/${card.id}',
+                headers: {
+                  "Origin": ADMIN_PORTAL_URL,
+                  "Authorization": "Bearer ${widget.userToken}"
+                },
+              ),
               selected: false,
               type: card.type,
             );

--- a/app/lib/views/pages/select_hair_style.dart
+++ b/app/lib/views/pages/select_hair_style.dart
@@ -5,7 +5,6 @@ import 'package:app/models/hair_length.dart';
 import 'package:app/models/hair_style.dart';
 import 'package:app/models/history.dart';
 import 'package:app/models/picture.dart';
-import 'package:app/services/authentication.dart';
 import 'package:app/services/constants.dart';
 import 'package:app/services/hair_style.dart';
 import 'package:app/services/model_pictures.dart';
@@ -137,7 +136,8 @@ class _SelectHairStyleState extends State<SelectHairStyle> {
     final hairStyleResponse =
         await HairStyleService.getById(id: historyHairStyleId);
 
-    if (hairStyleResponse.statusCode == HttpStatus.ok &&
+    if (hairStyleResponse != null &&
+        hairStyleResponse.statusCode == HttpStatus.ok &&
         hairStyleResponse.body.isNotEmpty) {
       final hairStyle = HairStyle.fromJson(jsonDecode(hairStyleResponse.body));
 
@@ -151,14 +151,12 @@ class _SelectHairStyleState extends State<SelectHairStyle> {
       _isLoading = true;
     });
 
-    print(
-        'Changing to this hair style: ${_selectedHairStyle.label} (ID = ${_selectedHairStyle.id})');
-
     final hairStyleChangeResponse = await PicturesService.changeHairStyle(
         userPictureId: widget.currentUserPicture.id,
         modelPictureId: _selectedHairStyle.id);
 
-    if (hairStyleChangeResponse.statusCode == HttpStatus.ok &&
+    if (hairStyleChangeResponse != null &&
+        hairStyleChangeResponse.statusCode == HttpStatus.ok &&
         hairStyleChangeResponse.body.isNotEmpty) {
       final History historyEntry =
           History.fromJson(jsonDecode(hairStyleChangeResponse.body));
@@ -177,7 +175,7 @@ class _SelectHairStyleState extends State<SelectHairStyle> {
       NotificationService.notify(
           scaffoldKey: _scaffoldKey,
           message:
-              "Failed to change hair style. Please try a different picture.");
+              "Failed to change hair style. Please try again or use a different picture.");
     }
 
     setState(() {
@@ -316,28 +314,26 @@ class _SelectHairStyleState extends State<SelectHairStyle> {
                 Container(
                   width: 200.0,
                   height: 40.0,
-                  child: MaterialButton(
-                    disabledColor: Colors.grey[600],
-                    disabledTextColor: Colors.white,
-                    onPressed: !_isLoading
-                        ? () async {
+                  child: !_isLoading
+                      ? MaterialButton(
+                          disabledColor: Colors.grey[600],
+                          disabledTextColor: Colors.white,
+                          onPressed: () async {
                             await _saveChanges();
-                          }
-                        : null,
-                    color: Color.fromARGB(255, 74, 169, 242),
-                    minWidth: double.infinity,
-                    child: !_isLoading
-                        ? Text(
+                          },
+                          color: Color.fromARGB(255, 74, 169, 242),
+                          minWidth: double.infinity,
+                          child: Text(
                             'Save changes',
                             style: Theme.of(context)
                                 .textTheme
                                 .bodyText1
                                 .copyWith(color: Colors.white),
-                          )
-                        : Center(
-                            child: CircularProgressIndicator(),
                           ),
-                  ),
+                        )
+                      : Center(
+                          child: CircularProgressIndicator(),
+                        ),
                 ),
                 const Padding(
                   padding: EdgeInsets.symmetric(vertical: 10.0),

--- a/app/lib/widgets/preview.dart
+++ b/app/lib/widgets/preview.dart
@@ -1,0 +1,48 @@
+import 'package:app/services/constants.dart';
+import 'package:flutter/material.dart';
+import 'package:photo_view/photo_view.dart';
+
+class Preview extends StatelessWidget {
+  final String previewPictureUrl;
+  final String origin;
+  final String userToken;
+
+  const Preview({
+    Key key,
+    @required this.previewPictureUrl,
+    this.origin = ADMIN_PORTAL_URL,
+    @required this.userToken,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        backgroundColor: Color.fromARGB(255, 96, 96, 96),
+        appBar: AppBar(
+            leading: GestureDetector(
+              onTap: () {
+                Navigator.pop(context);
+              },
+              child: Icon(Icons.close),
+            ),
+            title: Text(
+              'Current picture preview',
+              style: TextStyle(fontFamily: 'Klavika'),
+            )),
+        body: Container(
+            child: PhotoView(
+                enableRotation: true,
+                loadingBuilder: (context, event) => Center(
+                      child: CircularProgressIndicator(),
+                    ),
+                loadFailedChild: Center(
+                    child: Icon(
+                  Icons.broken_image,
+                  size: 128.0,
+                )),
+                imageProvider: NetworkImage(previewPictureUrl, headers: {
+                  "Origin": origin,
+                  "Authorization": "Bearer $userToken"
+                }))));
+  }
+}

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -15,13 +15,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0-nullsafety.1"
-  cached_network_image:
-    dependency: "direct main"
-    description:
-      name: cached_network_image
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.3.3"
   characters:
     dependency: transitive
     description:
@@ -57,13 +50,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.1"
-  crypto:
-    dependency: transitive
-    description:
-      name: crypto
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.5"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -97,20 +83,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_blurhash:
-    dependency: transitive
-    description:
-      name: flutter_blurhash
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.5.0"
-  flutter_cache_manager:
-    dependency: transitive
-    description:
-      name: flutter_cache_manager
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -191,13 +163,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0-nullsafety.3"
-  octo_image:
-    dependency: transitive
-    description:
-      name: octo_image
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.3.0"
   path:
     dependency: transitive
     description:
@@ -268,6 +233,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.0"
+  photo_view:
+    dependency: "direct main"
+    description:
+      name: photo_view
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.10.2"
   platform:
     dependency: transitive
     description:
@@ -289,13 +261,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.13"
-  rxdart:
-    dependency: transitive
-    description:
-      name: rxdart
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.24.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -308,20 +273,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0-nullsafety.2"
-  sqflite:
-    dependency: transitive
-    description:
-      name: sqflite
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1+1"
-  sqflite_common:
-    dependency: transitive
-    description:
-      name: sqflite_common
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.2+1"
   stack_trace:
     dependency: transitive
     description:
@@ -343,13 +294,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0-nullsafety.1"
-  synchronized:
-    dependency: transitive
-    description:
-      name: synchronized
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.2.0+2"
   term_glyph:
     dependency: transitive
     description:
@@ -371,13 +315,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0-nullsafety.3"
-  uuid:
-    dependency: transitive
-    description:
-      name: uuid
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.2.2"
   vector_math:
     dependency: transitive
     description:
@@ -408,4 +345,4 @@ packages:
     version: "4.5.1"
 sdks:
   dart: ">=2.10.0-110 <2.11.0"
-  flutter: ">=1.20.0 <2.0.0"
+  flutter: ">=1.18.0-6.0.pre <2.0.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   path_provider: ^1.6.18
   image_picker: ^0.6.7+12
   hexcolor: ^1.0.6
-  cached_network_image: ^2.3.3
+  photo_view: ^0.10.2
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
Major changes:

- From now on, the API does not throw an exception if a new hair style or hair colour cannot be applied to the current picture (it returns 422 instead)
- `previous_picture_id` is now being properly added to new history entries 
- Fixed `original_picture_id` for new history entries
- Completed routes are now reset when user uploads new pictures
- Implemented picture preview